### PR TITLE
feat: add TeamShifts component registration with top-level URL and dashboard widget signal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 ignore = N802,W503,E402
 max-line-length = 160
-exclude = migrations,.ropeproject,static,_static,build
+exclude = migrations,.ropeproject,static,_static,build,.venv
 
 [isort]
 profile = black

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
 from setuptools import setup
 
-
 setup()

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -1,5 +1,6 @@
 from django.dispatch import receiver
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from eventyay.control.signals import event_dashboard_components, event_dashboard_widgets
 
@@ -31,20 +32,14 @@ def teamshifts_dashboard_component(sender, request=None, **kwargs):
             "event": sender.slug,
         },
     )
-    return (
+    return format_html(
         '<div class="panel panel-default widget-container widget-small no-padding last-column">'
-        '<div class="panel-heading">'
-        '<h3 class="panel-title">{title}</h3>'
-        "</div>"
-        '<div class="panel-body">'
-        "<p>{description}</p>"
-        '<p>{go_to} <a href="{url}">{link_text}</a></p>'
-        "</div>"
-        "</div>"
-    ).format(
-        title=str(_("TeamShifts")),
-        description=str(_("Manage event teams, define team roles, review team member applications, and build a shift schedule for your event staff.")),
-        go_to=str(_("Go to")),
-        url=url,
-        link_text=str(_("TeamShifts Dashboard")),
+        '<div class="panel-heading"><h3 class="panel-title">{}</h3></div>'
+        '<div class="panel-body"><p>{}</p><p>{} <a href="{}">{}</a></p></div>'
+        "</div>",
+        str(_("TeamShifts")),
+        str(_("Manage event teams, define team roles, review team member applications, and build a shift schedule for your event staff.")),
+        str(_("Go to")),
+        url,
+        str(_("TeamShifts Dashboard")),
     )

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -1,7 +1,6 @@
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-
 from eventyay.control.signals import event_dashboard_components, event_dashboard_widgets
 
 
@@ -41,7 +40,7 @@ def teamshifts_dashboard_component(sender, request=None, **kwargs):
         "</div>"
         '<div class="panel-body">'
         "<p>{description}</p>"
-        '<p><a href="{url}">{link_text}</a></p>'
+        "<p>{go_to} <a href=\"{url}\">{link_text}</a></p>"
         "</div>"
         "</div>"
     ).format(
@@ -52,6 +51,7 @@ def teamshifts_dashboard_component(sender, request=None, **kwargs):
                 " applications, and build a shift schedule for your event staff."
             )
         ),
+        go_to=str(_("Go to")),
         url=url,
-        link_text=str(_("Go to TeamShifts Dashboard")),
+        link_text=str(_("TeamShifts Dashboard")),
     )

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -1,0 +1,28 @@
+from django.dispatch import receiver
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from eventyay.control.signals import event_dashboard_widgets
+
+
+@receiver(event_dashboard_widgets, dispatch_uid="teamshifts_dashboard_widget")
+def teamshifts_dashboard_widget(sender, subevent=None, lazy=False, **kwargs):
+    return [
+        {
+            "content": (
+                '<div class="numwidget">'
+                '<span class="num">-</span>'
+                '<span class="text">{}</span>'
+                "</div>"
+            ).format(str(_("TeamShifts"))),
+            "display_size": "small",
+            "priority": 80,
+            "url": reverse(
+                "plugins:teamshifts:dashboard",
+                kwargs={
+                    "organizer": sender.organizer.slug,
+                    "event": sender.slug,
+                },
+            ),
+        }
+    ]

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -8,9 +8,7 @@ from eventyay.control.signals import event_dashboard_components, event_dashboard
 def teamshifts_dashboard_widget(sender, subevent=None, lazy=False, **kwargs):
     return [
         {
-            "content": ('<div class="numwidget"><span class="num">-</span><span class="text">{}</span></div>').format(
-                str(_("TeamShifts"))
-            ),
+            "content": ('<div class="numwidget"><span class="num">-</span><span class="text">{}</span></div>').format(str(_("TeamShifts"))),
             "display_size": "small",
             "priority": 80,
             "url": reverse(
@@ -40,17 +38,12 @@ def teamshifts_dashboard_component(sender, request=None, **kwargs):
         "</div>"
         '<div class="panel-body">'
         "<p>{description}</p>"
-        "<p>{go_to} <a href=\"{url}\">{link_text}</a></p>"
+        '<p>{go_to} <a href="{url}">{link_text}</a></p>'
         "</div>"
         "</div>"
     ).format(
         title=str(_("TeamShifts")),
-        description=str(
-            _(
-                "Manage event teams, define team roles, review team member"
-                " applications, and build a shift schedule for your event staff."
-            )
-        ),
+        description=str(_("Manage event teams, define team roles, review team member applications, and build a shift schedule for your event staff.")),
         go_to=str(_("Go to")),
         url=url,
         link_text=str(_("TeamShifts Dashboard")),

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -1,7 +1,6 @@
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-
 from eventyay.control.signals import event_dashboard_widgets
 
 
@@ -9,12 +8,7 @@ from eventyay.control.signals import event_dashboard_widgets
 def teamshifts_dashboard_widget(sender, subevent=None, lazy=False, **kwargs):
     return [
         {
-            "content": (
-                '<div class="numwidget">'
-                '<span class="num">-</span>'
-                '<span class="text">{}</span>'
-                "</div>"
-            ).format(str(_("TeamShifts"))),
+            "content": ('<div class="numwidget"><span class="num">-</span><span class="text">{}</span></div>').format(str(_("TeamShifts"))),
             "display_size": "small",
             "priority": 80,
             "url": reverse(

--- a/teamshifts/signals.py
+++ b/teamshifts/signals.py
@@ -1,14 +1,17 @@
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from eventyay.control.signals import event_dashboard_widgets
+
+from eventyay.control.signals import event_dashboard_components, event_dashboard_widgets
 
 
 @receiver(event_dashboard_widgets, dispatch_uid="teamshifts_dashboard_widget")
 def teamshifts_dashboard_widget(sender, subevent=None, lazy=False, **kwargs):
     return [
         {
-            "content": ('<div class="numwidget"><span class="num">-</span><span class="text">{}</span></div>').format(str(_("TeamShifts"))),
+            "content": ('<div class="numwidget"><span class="num">-</span><span class="text">{}</span></div>').format(
+                str(_("TeamShifts"))
+            ),
             "display_size": "small",
             "priority": 80,
             "url": reverse(
@@ -20,3 +23,35 @@ def teamshifts_dashboard_widget(sender, subevent=None, lazy=False, **kwargs):
             ),
         }
     ]
+
+
+@receiver(event_dashboard_components, dispatch_uid="teamshifts_dashboard_component")
+def teamshifts_dashboard_component(sender, request=None, **kwargs):
+    url = reverse(
+        "plugins:teamshifts:dashboard",
+        kwargs={
+            "organizer": sender.organizer.slug,
+            "event": sender.slug,
+        },
+    )
+    return (
+        '<div class="panel panel-default widget-container widget-small no-padding last-column">'
+        '<div class="panel-heading">'
+        '<h3 class="panel-title">{title}</h3>'
+        "</div>"
+        '<div class="panel-body">'
+        "<p>{description}</p>"
+        '<p><a href="{url}">{link_text}</a></p>'
+        "</div>"
+        "</div>"
+    ).format(
+        title=str(_("TeamShifts")),
+        description=str(
+            _(
+                "Manage event teams, define team roles, review team member"
+                " applications, and build a shift schedule for your event staff."
+            )
+        ),
+        url=url,
+        link_text=str(_("Go to TeamShifts Dashboard")),
+    )

--- a/teamshifts/templates/teamshifts/base.html
+++ b/teamshifts/templates/teamshifts/base.html
@@ -1,0 +1,7 @@
+{% extends "pretixcontrol/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ request.event.name }} — {% trans "TeamShifts" %}{% endblock %}
+
+{% block nav %}
+{% endblock %}

--- a/teamshifts/templates/teamshifts/dashboard.html
+++ b/teamshifts/templates/teamshifts/dashboard.html
@@ -1,0 +1,16 @@
+{% extends "teamshifts/base.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{% trans "TeamShifts" %}</h1>
+<p class="text-muted">
+    {% blocktrans trimmed with name=event.name %}
+        Team and shift management for <strong>{{ name }}</strong>.
+        Manage event teams, team roles, and shift scheduling from here.
+    {% endblocktrans %}
+</p>
+
+<div class="alert alert-info">
+    {% trans "This component is being set up. Team management features will be available in the next phase." %}
+</div>
+{% endblock %}

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-
 from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
 
 from . import views

--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
+
+from . import views
+
+urlpatterns = [
+    path(
+        "teamshifts/event/<orgslug:organizer>/<slug:event>/",
+        views.TeamShiftsDashboard.as_view(),
+        name="dashboard",
+    ),
+]

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1,5 +1,4 @@
 from django.views.generic import TemplateView
-
 from eventyay.control.permissions import EventPermissionRequiredMixin
 
 

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -1,0 +1,13 @@
+from django.views.generic import TemplateView
+
+from eventyay.control.permissions import EventPermissionRequiredMixin
+
+
+class TeamShiftsDashboard(EventPermissionRequiredMixin, TemplateView):
+    permission = "can_change_event_settings"
+    template_name = "teamshifts/dashboard.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["event"] = self.request.event
+        return ctx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,3 @@
-import importlib
-
-
 def test_plugin_version():
     import teamshifts
 
@@ -10,10 +7,10 @@ def test_plugin_version():
 def test_appconfig_meta():
     try:
         from teamshifts.apps import TeamShiftsApp
-    except RuntimeError:
+    except (RuntimeError, ModuleNotFoundError):
         import pytest
 
-        pytest.skip("eventyay not installed, skipping AppConfig test")
+        pytest.skip("eventyay or Django not installed, skipping AppConfig test")
 
     assert TeamShiftsApp.name == "teamshifts"
     meta = TeamShiftsApp.EventyayPluginMeta


### PR DESCRIPTION
#### Overview

This PR registers the TeamShifts plugin as a standalone event component with its own top-level URL namespace, dashboard widget signal, and component panel signal.

#### Changes

- **Views**: `TeamShiftsDashboard` with `EventPermissionRequiredMixin` and `can_change_event_settings` permission
- **URLs**: Top-level `teamshifts/event/<orgslug:organizer>/<slug:event>/` path (auto-discovered under `plugins:teamshifts` namespace)
- **Signals**:
  - `event_dashboard_widgets` receiver — small numwidget on per-event dashboard (only fires when plugin is enabled)
  - `event_dashboard_components` receiver — full component panel with title, description, and "Go to TeamShifts Dashboard" link
- **Templates**: `base.html` (isolated layout with empty sidebar), `dashboard.html` (stub content)

#### Design Decisions

- `event_dashboard_components` (`EventPluginSignal`) injects the component panel — signal-based, no hardcoded template checks in core
- `event_dashboard_widgets` (`EventPluginSignal`) is used for the numwidget — same auto-gating
- `nav_event` is intentionally NOT used — it adds items to the Tickets sidebar, which is incorrect for a separate component
- `nav_global` / "My Shifts" is deferred to a future phase

#### Verification

- Enable plugin from Plugins tab → component panel and numwidget appear on event dashboard
- Disable plugin → both disappear
- `GET /teamshifts/event/<org>/<event>/` returns 200 for authorised organisers
- Unauthenticated requests redirect to login

#### Note

- Requires a companion PR against the `eventyay` core repo that adds the `event_dashboard_components` signal, middleware patch, and `{% eventsignal %}` in the template.
- Tests and config files updated to prevent CI failures.

#### Related

- Closes #12
- Closes #13
- Depends on: #7
- Part of: #6 (Roadmap)



https://github.com/user-attachments/assets/c71768de-ee2f-463a-abf1-9c8e7b739ab1

