### PR TITLE
feat: unified default + custom fields with per-field configuration

### DIFF
--- a/teamshifts/admin.py
+++ b/teamshifts/admin.py
@@ -63,10 +63,10 @@ class ShiftAssignmentAdmin(admin.ModelAdmin):
 
 @admin.register(TeamApplicationQuestion)
 class TeamApplicationQuestionAdmin(admin.ModelAdmin):
-    list_display = ("event", "role", "variant", "required", "position", "active")
+    list_display = ("event", "role", "variant", "required", "active")
     list_filter = ("variant", "required", "active", "event__organizer")
     search_fields = ("event__slug", "role__name")
-    ordering = ("event", "role", "position")
+    ordering = ("event", "role", "pk")
 
 
 @admin.register(TeamApplicationAnswer)

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -4,17 +4,29 @@ from django_countries import countries
 from django_scopes import scopes_disabled
 
 from .models import (
+    CFM_BUILTIN_FIELD_KEYS,
+    AskChoices,
     CallForTeamMembers,
     QuestionVariant,
     TeamApplicationQuestion,
     TeamRole,
+    normalize_field_order,
 )
 
 
 class CallForTeamMembersForm(forms.ModelForm):
     class Meta:
         model = CallForTeamMembers
-        fields = ("title", "active", "show_on_menu", "deadline", "description")
+        fields = (
+            "title",
+            "active",
+            "show_on_menu",
+            "deadline",
+            "description",
+            "ask_full_name",
+            "ask_phone",
+            "ask_availability",
+        )
         widgets = {
             "deadline": forms.DateTimeInput(
                 attrs={"class": "form-control datetimepicker"},
@@ -51,12 +63,11 @@ class TeamApplicationQuestionForm(forms.ModelForm):
 
     class Meta:
         model = TeamApplicationQuestion
-        fields = ("role", "question", "help_text", "variant", "required", "options", "active", "position")
+        fields = ("role", "question", "help_text", "variant", "required", "options", "active")
         widgets = {
             "options": forms.Textarea(
                 attrs={"class": "form-control", "rows": 3, "placeholder": _("One option per line")},
             ),
-            "position": forms.NumberInput(attrs={"class": "form-control", "min": 0}),
             "variant": forms.Select(attrs={"class": "form-control"}),
         }
 
@@ -89,68 +100,110 @@ class TeamApplicationQuestionForm(forms.ModelForm):
 
 
 class TeamMemberApplicationForm(forms.Form):
-    name = forms.CharField(
-        label=_("Full name"),
-        widget=forms.TextInput(attrs={"class": "form-control"}),
-    )
-    email = forms.EmailField(
-        label=_("Email address"),
-        widget=forms.EmailInput(attrs={"class": "form-control", "readonly": True}),
-        help_text=_("To change your email address, visit your account settings."),
-    )
-    phone = forms.CharField(
-        required=False,
-        label=_("Phone / Mobile"),
-        help_text=_("Optional. We may use this to contact you regarding your shift."),
-        widget=forms.TextInput(attrs={"class": "form-control", "type": "tel", "placeholder": "+1 555 000 0000"}),
-    )
-    role = forms.ModelChoiceField(
-        queryset=TeamRole.objects.none(),
-        label=_("Role you are applying for"),
-        empty_label=_("— Select a role —"),
-        widget=forms.Select(attrs={"class": "form-control", "id": "id_role"}),
-    )
-    availability_notes = forms.CharField(
-        required=False,
-        label=_("Availability notes"),
-        help_text=_("Which days/hours can you commit to?"),
-        widget=forms.Textarea(attrs={"class": "form-control", "rows": 4}),
-    )
-
     QUESTION_FIELD_PREFIX = "question_"
 
-    def __init__(self, *args, event=None, user=None, applied_role_ids=(), **kwargs):
+    def __init__(self, *args, event=None, user=None, applied_role_ids=(), cfm=None, **kwargs):
         super().__init__(*args, **kwargs)
         self._event = event
-        self._questions = []
+        self._questions: list[TeamApplicationQuestion] = []
+        self._field_order_keys: list = []
+
         if user is not None:
-            self.fields["name"].initial = user.fullname or ""
-            self.fields["email"].initial = user.email
+            self._user = user
+        else:
+            self._user = None
+
         if event is None:
             return
+
         with scopes_disabled():
-            self.fields["role"].queryset = TeamRole.objects.filter(event=event).exclude(pk__in=applied_role_ids)
+            role_qs = TeamRole.objects.filter(event=event).exclude(pk__in=applied_role_ids)
             self._questions = list(TeamApplicationQuestion.objects.filter(event=event, active=True).order_by("position", "pk"))
-        for question in self._questions:
-            field = self._build_field_for_question(question)
-            role_pk = str(question.role_id) if question.role_id else ""
-            field.widget.attrs["data-question-role"] = role_pk
-            field.widget.attrs["data-question-field"] = "1"
-            if question.role_id:
-                field.required = False
-            self.fields[self._field_name_for(question)] = field
+
+        question_map: dict[int, TeamApplicationQuestion] = {q.pk: q for q in self._questions}
+
+        if cfm is not None:
+            raw_order = normalize_field_order(list(cfm.field_order))
+        else:
+            raw_order = list(CFM_BUILTIN_FIELD_KEYS)
+
+        for item in raw_order:
+            if isinstance(item, str):
+                ask_state = cfm.get_ask_state(item) if cfm else AskChoices.OPTIONAL
+                if ask_state == AskChoices.DO_NOT_ASK:
+                    continue
+                required = ask_state == AskChoices.REQUIRED
+                self._field_order_keys.append(item)
+
+                if item == "role":
+                    field = forms.ModelChoiceField(
+                        queryset=role_qs,
+                        label=_("Role you are applying for"),
+                        required=True,
+                        empty_label=_("— Select a role —"),
+                        widget=forms.Select(attrs={"class": "form-control", "id": "id_role"}),
+                    )
+                    self.fields["role"] = field
+                elif item == "full_name":
+                    field = forms.CharField(
+                        label=_("Full name"),
+                        required=required,
+                        widget=forms.TextInput(attrs={"class": "form-control"}),
+                    )
+                    if user is not None:
+                        field.initial = user.fullname or ""
+                    self.fields["full_name"] = field
+                elif item == "email":
+                    field = forms.EmailField(
+                        label=_("Email address"),
+                        required=True,
+                        widget=forms.EmailInput(attrs={"class": "form-control", "readonly": True}),
+                        help_text=_("To change your email address, visit your account settings."),
+                    )
+                    if user is not None:
+                        field.initial = user.email
+                    self.fields["email"] = field
+                elif item == "phone":
+                    field = forms.CharField(
+                        label=_("Phone / Mobile"),
+                        required=required,
+                        help_text=_("Optional. We may use this to contact you regarding your shift."),
+                        widget=forms.TextInput(attrs={"class": "form-control", "type": "tel", "placeholder": "+1 555 000 0000"}),
+                    )
+                    self.fields["phone"] = field
+                elif item == "availability":
+                    field = forms.CharField(
+                        label=_("Availability notes"),
+                        required=required,
+                        help_text=_("Which days/hours can you commit to?"),
+                        widget=forms.Textarea(attrs={"class": "form-control", "rows": 4}),
+                    )
+                    self.fields["availability_notes"] = field
+            else:
+                pk = int(item)
+                question = question_map.get(pk)
+                if question is None:
+                    continue
+                self._field_order_keys.append(item)
+                field = self._build_field_for_question(question)
+                role_pk = str(question.role_id) if question.role_id else ""
+                field.widget.attrs["data-question-role"] = role_pk
+                field.widget.attrs["data-question-field"] = "1"
+                if question.role_id:
+                    field.required = False
+                self.fields[self._field_name_for(question)] = field
 
     @staticmethod
-    def _field_name_for(question):
+    def _field_name_for(question: TeamApplicationQuestion) -> str:
         return f"{TeamMemberApplicationForm.QUESTION_FIELD_PREFIX}{question.pk}"
 
     @staticmethod
-    def _build_field_for_question(question):
+    def _build_field_for_question(question: TeamApplicationQuestion) -> forms.Field:
         label = str(question.question)
         help_text = str(question.help_text) if question.help_text else ""
         required = bool(question.required)
         variant = question.variant
-        common = {"label": label, "help_text": help_text, "required": required}
+        common: dict = {"label": label, "help_text": help_text, "required": required}
 
         if variant == QuestionVariant.STRING:
             return forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}), **common)
@@ -199,7 +252,7 @@ class TeamMemberApplicationForm(forms.Form):
             return forms.MultipleChoiceField(choices=options, widget=forms.CheckboxSelectMultiple, **common)
         return forms.CharField(widget=forms.TextInput(attrs={"class": "form-control"}), **common)
 
-    def visible_questions(self):
+    def visible_questions(self) -> list[tuple[TeamApplicationQuestion, forms.BoundField]]:
         return [(q, self[self._field_name_for(q)]) for q in self._questions]
 
     def clean(self):
@@ -220,11 +273,11 @@ class TeamMemberApplicationForm(forms.Form):
                 self.add_error(self._field_name_for(question), _("This field is required."))
         return cleaned
 
-    def get_question_answers(self):
+    def get_question_answers(self) -> list[tuple[TeamApplicationQuestion, str]]:
         return [(q, self._serialize_answer(q, self.cleaned_data.get(self._field_name_for(q)))) for q in self._questions]
 
     @staticmethod
-    def _serialize_answer(question, value):
+    def _serialize_answer(question: TeamApplicationQuestion, value) -> str:
         if value is None or value == "":
             return ""
         variant = question.variant
@@ -239,7 +292,7 @@ class TeamMemberApplicationForm(forms.Form):
         return str(value)
 
 
-def render_answer_for_review(question, answer_text):
+def render_answer_for_review(question: TeamApplicationQuestion, answer_text: str) -> str:
     if not answer_text:
         return ""
     if question.variant == QuestionVariant.BOOLEAN:

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -118,7 +118,7 @@ class TeamMemberApplicationForm(forms.Form):
 
         with scopes_disabled():
             role_qs = TeamRole.objects.filter(event=event).exclude(pk__in=applied_role_ids)
-            self._questions = list(TeamApplicationQuestion.objects.filter(event=event, active=True).order_by("position", "pk"))
+            self._questions = list(TeamApplicationQuestion.objects.filter(event=event, active=True).order_by("pk"))
 
         question_map: dict[int, TeamApplicationQuestion] = {q.pk: q for q in self._questions}
 

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -127,6 +127,12 @@ class TeamMemberApplicationForm(forms.Form):
         else:
             raw_order = list(CFM_BUILTIN_FIELD_KEYS)
 
+        raw_order = [int(i) if isinstance(i, str) and i.isdigit() else i for i in raw_order]
+        present_question_pks = {i for i in raw_order if isinstance(i, int)}
+        for q in self._questions:
+            if q.pk not in present_question_pks:
+                raw_order.append(q.pk)
+
         for item in raw_order:
             if isinstance(item, str):
                 ask_state = cfm.get_ask_state(item) if cfm else AskChoices.OPTIONAL
@@ -188,7 +194,9 @@ class TeamMemberApplicationForm(forms.Form):
                 field = self._build_field_for_question(question)
                 role_pk = str(question.role_id) if question.role_id else ""
                 field.widget.attrs["data-question-role"] = role_pk
+                field.widget.attrs["data_question_role"] = role_pk
                 field.widget.attrs["data-question-field"] = "1"
+                field.widget.attrs["data_question_field"] = "1"
                 if question.role_id:
                     field.required = False
                 self.fields[self._field_name_for(question)] = field
@@ -254,6 +262,22 @@ class TeamMemberApplicationForm(forms.Form):
 
     def visible_questions(self) -> list[tuple[TeamApplicationQuestion, forms.BoundField]]:
         return [(q, self[self._field_name_for(q)]) for q in self._questions]
+
+    def render_items(self):
+        """Yield {field, is_question, role_id} for the template so it can wrap
+        role-scoped custom question fields without needing dashed-attr lookup."""
+        question_map = {q.pk: q for q in self._questions}
+        for name in self.fields:
+            if name.startswith(self.QUESTION_FIELD_PREFIX):
+                try:
+                    pk = int(name[len(self.QUESTION_FIELD_PREFIX) :])
+                except ValueError:
+                    continue
+                question = question_map.get(pk)
+                role_id = str(question.role_id) if question and question.role_id else ""
+                yield {"field": self[name], "is_question": True, "role_id": role_id}
+            else:
+                yield {"field": self[name], "is_question": False, "role_id": ""}
 
     def clean(self):
         cleaned = super().clean()

--- a/teamshifts/migrations/0004_cfm_configurable_default_fields.py
+++ b/teamshifts/migrations/0004_cfm_configurable_default_fields.py
@@ -1,0 +1,78 @@
+from django.db import migrations, models
+
+
+def seed_field_order(apps, schema_editor):
+    CallForTeamMembers = apps.get_model("teamshifts", "CallForTeamMembers")
+    TeamApplicationQuestion = apps.get_model("teamshifts", "TeamApplicationQuestion")
+
+    builtin_keys = ["full_name", "email", "phone", "role", "availability"]
+
+    for cfm in CallForTeamMembers.objects.all():
+        custom_pks = list(TeamApplicationQuestion.objects.filter(event_id=cfm.event_id).order_by("position", "pk").values_list("pk", flat=True))
+        cfm.field_order = builtin_keys + custom_pks
+        cfm.save(update_fields=["field_order"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("teamshifts", "0003_callforteammembers_show_on_menu"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="callforteammembers",
+            name="ask_full_name",
+            field=models.CharField(
+                choices=[("do_not_ask", "Do not ask"), ("optional", "Optional"), ("required", "Required")],
+                default="optional",
+                max_length=20,
+                verbose_name="Full name",
+            ),
+        ),
+        migrations.AddField(
+            model_name="callforteammembers",
+            name="ask_email",
+            field=models.CharField(
+                choices=[("do_not_ask", "Do not ask"), ("optional", "Optional"), ("required", "Required")],
+                default="required",
+                max_length=20,
+                verbose_name="Email address",
+            ),
+        ),
+        migrations.AddField(
+            model_name="callforteammembers",
+            name="ask_phone",
+            field=models.CharField(
+                choices=[("do_not_ask", "Do not ask"), ("optional", "Optional"), ("required", "Required")],
+                default="optional",
+                max_length=20,
+                verbose_name="Phone / Mobile",
+            ),
+        ),
+        migrations.AddField(
+            model_name="callforteammembers",
+            name="ask_role",
+            field=models.CharField(
+                choices=[("do_not_ask", "Do not ask"), ("optional", "Optional"), ("required", "Required")],
+                default="required",
+                max_length=20,
+                verbose_name="Role",
+            ),
+        ),
+        migrations.AddField(
+            model_name="callforteammembers",
+            name="ask_availability",
+            field=models.CharField(
+                choices=[("do_not_ask", "Do not ask"), ("optional", "Optional"), ("required", "Required")],
+                default="optional",
+                max_length=20,
+                verbose_name="Availability notes",
+            ),
+        ),
+        migrations.AddField(
+            model_name="callforteammembers",
+            name="field_order",
+            field=models.JSONField(default=list, verbose_name="Field order"),
+        ),
+        migrations.RunPython(seed_field_order, migrations.RunPython.noop),
+    ]

--- a/teamshifts/migrations/0004_cfm_configurable_default_fields.py
+++ b/teamshifts/migrations/0004_cfm_configurable_default_fields.py
@@ -1,18 +1,6 @@
 from django.db import migrations, models
 
 
-def seed_field_order(apps, schema_editor):
-    CallForTeamMembers = apps.get_model("teamshifts", "CallForTeamMembers")
-    TeamApplicationQuestion = apps.get_model("teamshifts", "TeamApplicationQuestion")
-
-    builtin_keys = ["full_name", "email", "phone", "role", "availability"]
-
-    for cfm in CallForTeamMembers.objects.all():
-        custom_pks = list(TeamApplicationQuestion.objects.filter(event_id=cfm.event_id).order_by("position", "pk").values_list("pk", flat=True))
-        cfm.field_order = builtin_keys + custom_pks
-        cfm.save(update_fields=["field_order"])
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ("teamshifts", "0003_callforteammembers_show_on_menu"),
@@ -74,5 +62,4 @@ class Migration(migrations.Migration):
             name="field_order",
             field=models.JSONField(default=list, verbose_name="Field order"),
         ),
-        migrations.RunPython(seed_field_order, migrations.RunPython.noop),
     ]

--- a/teamshifts/migrations/0005_remove_teamapplicationquestion_position.py
+++ b/teamshifts/migrations/0005_remove_teamapplicationquestion_position.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("teamshifts", "0004_cfm_configurable_default_fields"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="teamapplicationquestion",
+            options={
+                "ordering": ["pk"],
+                "verbose_name": "Application Question",
+                "verbose_name_plural": "Application Questions",
+            },
+        ),
+        migrations.RemoveField(
+            model_name="teamapplicationquestion",
+            name="position",
+        ),
+    ]

--- a/teamshifts/models.py
+++ b/teamshifts/models.py
@@ -5,11 +5,38 @@ from django.utils.translation import gettext_lazy as _
 from django_scopes import ScopedManager
 from i18nfield.fields import I18nTextField
 
+CFM_BUILTIN_FIELD_KEYS = ("full_name", "email", "phone", "role", "availability")
+
+CFM_LOCKED_FIELDS = frozenset({"email", "role"})
+
+
+def normalize_field_order(order: list) -> list:
+    builtin = list(CFM_BUILTIN_FIELD_KEYS)
+    builtin_set = set(builtin)
+    missing = [f for f in builtin if f not in order]
+    if not missing:
+        return order
+    result = list(order)
+    for field in missing:
+        canonical_idx = builtin.index(field)
+        insert_after = -1
+        for i, item in enumerate(result):
+            if item in builtin_set and builtin.index(item) < canonical_idx:
+                insert_after = i
+        result.insert(insert_after + 1, field)
+    return result
+
 
 class ApplicationStatus(models.TextChoices):
     PENDING = "pending", _("Pending")
     ACCEPTED = "accepted", _("Accepted")
     REJECTED = "rejected", _("Rejected")
+
+
+class AskChoices(models.TextChoices):
+    DO_NOT_ASK = "do_not_ask", _("Do not ask")
+    OPTIONAL = "optional", _("Optional")
+    REQUIRED = "required", _("Required")
 
 
 class CallForTeamMembers(models.Model):
@@ -39,6 +66,39 @@ class CallForTeamMembers(models.Model):
     )
     description = I18nTextField(verbose_name=_("Description"), blank=True, null=True)
 
+    ask_full_name = models.CharField(
+        max_length=20,
+        choices=AskChoices.choices,
+        default=AskChoices.OPTIONAL,
+        verbose_name=_("Full name"),
+    )
+    ask_email = models.CharField(
+        max_length=20,
+        choices=AskChoices.choices,
+        default=AskChoices.REQUIRED,
+        verbose_name=_("Email address"),
+    )
+    ask_phone = models.CharField(
+        max_length=20,
+        choices=AskChoices.choices,
+        default=AskChoices.OPTIONAL,
+        verbose_name=_("Phone / Mobile"),
+    )
+    ask_role = models.CharField(
+        max_length=20,
+        choices=AskChoices.choices,
+        default=AskChoices.REQUIRED,
+        verbose_name=_("Role"),
+    )
+    ask_availability = models.CharField(
+        max_length=20,
+        choices=AskChoices.choices,
+        default=AskChoices.OPTIONAL,
+        verbose_name=_("Availability notes"),
+    )
+
+    field_order = models.JSONField(default=list, verbose_name=_("Field order"))
+
     objects = ScopedManager(event="event")
 
     class Meta:
@@ -52,6 +112,16 @@ class CallForTeamMembers(models.Model):
         if self.deadline and timezone.now() > self.deadline:
             return False
         return True
+
+    def get_ask_state(self, field_key: str) -> str:
+        mapping = {
+            "full_name": self.ask_full_name,
+            "email": self.ask_email,
+            "phone": self.ask_phone,
+            "role": self.ask_role,
+            "availability": self.ask_availability,
+        }
+        return mapping.get(field_key, AskChoices.DO_NOT_ASK)
 
     def __str__(self):
         return f"{self.title} — {self.event.slug} ({'active' if self.active else 'inactive'})"

--- a/teamshifts/models.py
+++ b/teamshifts/models.py
@@ -321,7 +321,6 @@ class TeamApplicationQuestion(models.Model):
         verbose_name=_("Field type"),
     )
     required = models.BooleanField(default=False, verbose_name=_("Required"))
-    position = models.PositiveIntegerField(default=0, verbose_name=_("Position"))
     options = models.TextField(
         blank=True,
         verbose_name=_("Options"),
@@ -334,7 +333,7 @@ class TeamApplicationQuestion(models.Model):
     class Meta:
         verbose_name = _("Application Question")
         verbose_name_plural = _("Application Questions")
-        ordering = ["position", "pk"]
+        ordering = ["pk"]
 
     def clean(self):
         if self.role_id and self.event_id and self.role.event_id != self.event_id:

--- a/teamshifts/models.py
+++ b/teamshifts/models.py
@@ -114,6 +114,8 @@ class CallForTeamMembers(models.Model):
         return True
 
     def get_ask_state(self, field_key: str) -> str:
+        if field_key in CFM_LOCKED_FIELDS:
+            return AskChoices.REQUIRED
         mapping = {
             "full_name": self.ask_full_name,
             "email": self.ask_email,

--- a/teamshifts/static/teamshifts/cfv_settings.js
+++ b/teamshifts/static/teamshifts/cfv_settings.js
@@ -2,7 +2,6 @@ document.addEventListener('DOMContentLoaded', function () {
   var activeEl = document.getElementById('id_active');
   var showOnMenuEl = document.getElementById('id_show_on_menu');
   if (!activeEl || !showOnMenuEl) return;
-
   function updateShowOnMenu() {
     var row = showOnMenuEl.closest('.form-group') || showOnMenuEl.parentElement;
     if (!activeEl.checked) {
@@ -14,7 +13,6 @@ document.addEventListener('DOMContentLoaded', function () {
       if (row) row.style.opacity = '';
     }
   }
-
   activeEl.addEventListener('change', updateShowOnMenu);
   updateShowOnMenu();
 });

--- a/teamshifts/templates/teamshifts/apply.html
+++ b/teamshifts/templates/teamshifts/apply.html
@@ -9,101 +9,96 @@
 {% block testmode_alert %}{% endblock %}
 
 {% block custom_header %}
-    {{ block.super }}
-    <link rel='stylesheet' type='text/css' href='{% static "teamshifts/teamshifts.css" %}'>
-    <script type='module' src='{% static "teamshifts/apply.js" %}'></script>
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static 'teamshifts/teamshifts.css' %}">
+  <script type="module" src="{% static 'teamshifts/apply.js' %}"></script>
 {% endblock %}
 
 {% block content %}
-    <h2>{% if cfm %}{{ cfm.title }}{% else %}{% trans "Apply to join the team" %}{% endif %}</h2>
+  <h2>{% if cfm %}{{ cfm.title }}{% else %}{% trans "Apply to join the team" %}{% endif %}</h2>
 
-    {% if not cfm_open %}
-        <div class='alert alert-warning'>
-            {% if cfm_deadline_passed %}
-                <strong>{% blocktrans with deadline=cfm.deadline %}Applications closed on {{ deadline }}.{% endblocktrans %}</strong>
-                <p class='mb-0'>{% blocktrans with title=cfm.title %}{{ title }} is no longer accepting applications.{% endblocktrans %}</p>
-            {% else %}
-                <strong>{% trans "Applications are currently closed." %}</strong>
-                {% trans "This event is not accepting team member applications at this time." %}
-            {% endif %}
-        </div>
-    {% else %}
+  {% if not cfm_open %}
+    <div class="alert alert-warning">
+      {% if cfm_deadline_passed %}
+        <strong>{% blocktrans with deadline=cfm.deadline %}Applications closed on {{ deadline }}.{% endblocktrans %}</strong>
+        <p class="mb-0">{% blocktrans with title=cfm.title %}{{ title }} is no longer accepting applications.{% endblocktrans %}</p>
+      {% else %}
+        <strong>{% trans "Applications are currently closed." %}</strong>
+        {% trans "This event is not accepting team member applications at this time." %}
+      {% endif %}
+    </div>
+  {% else %}
 
-        {% if cfm.description %}
-            <div class='description-text' style='margin-bottom: 1.5em;'>{{ cfm.description }}</div>
-        {% endif %}
-
-        {% if existing_applications %}
-            <div class='panel panel-info' style='margin-bottom: 1.5em;'>
-                <div class='panel-heading'>
-                    <h3 class='panel-title'>{% trans "Your applications" %}</h3>
-                </div>
-                <div class='panel-body'>
-                    <div class='table-responsive'>
-                        <table class='table table-condensed'>
-                            <thead>
-                                <tr>
-                                    <th>{% trans "Role" %}</th>
-                                    <th>{% trans "Status" %}</th>
-                                    <th>{% trans "Applied" %}</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for app in existing_applications %}
-                                    <tr>
-                                        <td>{{ app.role.name }}</td>
-                                        <td>
-                                            {% if app.status == 'pending' %}
-                                                <span class='label label-warning'>{% trans "Pending" %}</span>
-                                            {% elif app.status == 'accepted' %}
-                                                <span class='label label-success'>{% trans "Accepted" %}</span>
-                                            {% else %}
-                                                <span class='label label-danger'>{% trans "Rejected" %}</span>
-                                            {% endif %}
-                                        </td>
-                                        <td>{{ app.created_at|date:"SHORT_DATETIME_FORMAT" }}</td>
-                                    </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-        {% endif %}
-
-        <div class='panel panel-default'>
-            <div class='panel-heading'>
-                <h3 class='panel-title'>{% trans "New application" %}</h3>
-            </div>
-            <div class='panel-body'>
-                <form action='' method='post' class='form-horizontal' id='teamshifts-apply-form'>
-                    {% csrf_token %}
-                    {% bootstrap_form_errors form %}
-                    {% bootstrap_field form.name layout='control' %}
-                    {% bootstrap_field form.email layout='control' %}
-                    {% bootstrap_field form.phone layout='control' %}
-                    {% bootstrap_field form.role layout='control' %}
-                    {% bootstrap_field form.availability_notes layout='control' %}
-                    {% if form.visible_questions %}
-                        <fieldset id='teamshifts-question-fields'>
-                            <legend>{% trans "Additional questions" %}</legend>
-                            {% for question, field in form.visible_questions %}
-                                <div class='teamshifts-question-row' data-question-role='{{ question.role_id|default_if_none:"" }}'>
-                                    {% bootstrap_field field layout='control' %}
-                                </div>
-                            {% endfor %}
-                        </fieldset>
-                    {% endif %}
-                    <div class='form-group'>
-                        <div class='col-md-9 col-md-offset-3 text-right'>
-                            <button type='submit' class='btn btn-primary btn-lg'>
-                                {% trans "Submit application" %} &raquo;
-                            </button>
-                        </div>
-                    </div>
-                </form>
-            </div>
-        </div>
-
+    {% if cfm.description %}
+      <div class="description-text" style="margin-bottom:1.5em;">{{ cfm.description }}</div>
     {% endif %}
+
+    {% if existing_applications %}
+      <div class="panel panel-info" style="margin-bottom:1.5em;">
+        <div class="panel-heading">
+          <h3 class="panel-title">{% trans "Your applications" %}</h3>
+        </div>
+        <div class="panel-body">
+          <div class="table-responsive">
+            <table class="table table-condensed">
+              <thead>
+                <tr>
+                  <th>{% trans "Role" %}</th>
+                  <th>{% trans "Status" %}</th>
+                  <th>{% trans "Applied" %}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for app in existing_applications %}
+                  <tr>
+                    <td>{{ app.role.name }}</td>
+                    <td>
+                      {% if app.status == 'pending' %}
+                        <span class="label label-warning">{% trans "Pending" %}</span>
+                      {% elif app.status == 'accepted' %}
+                        <span class="label label-success">{% trans "Accepted" %}</span>
+                      {% else %}
+                        <span class="label label-danger">{% trans "Rejected" %}</span>
+                      {% endif %}
+                    </td>
+                    <td>{{ app.created_at|date:"SHORT_DATETIME_FORMAT" }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">{% trans "New application" %}</h3>
+      </div>
+      <div class="panel-body">
+        <form action="" method="post" class="form-horizontal" id="teamshifts-apply-form">
+          {% csrf_token %}
+          {% bootstrap_form_errors form %}
+          {% for field in form %}
+            {% if field.field.widget.attrs.data-question-field %}
+              <div class="teamshifts-question-row"
+                   data-question-role="{{ field.field.widget.attrs.data-question-role|default:'' }}">
+                {% bootstrap_field field layout="control" %}
+              </div>
+            {% else %}
+              {% bootstrap_field field layout="control" %}
+            {% endif %}
+          {% endfor %}
+          <div class="form-group">
+            <div class="col-md-9 col-md-offset-3 text-right">
+              <button type="submit" class="btn btn-primary btn-lg">
+                {% trans "Submit application" %} &raquo;
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+
+  {% endif %}
 {% endblock %}

--- a/teamshifts/templates/teamshifts/apply.html
+++ b/teamshifts/templates/teamshifts/apply.html
@@ -79,14 +79,13 @@
         <form action="" method="post" class="form-horizontal" id="teamshifts-apply-form">
           {% csrf_token %}
           {% bootstrap_form_errors form %}
-          {% for field in form %}
-            {% if field.field.widget.attrs.data-question-field %}
-              <div class="teamshifts-question-row"
-                   data-question-role="{{ field.field.widget.attrs.data-question-role|default:'' }}">
-                {% bootstrap_field field layout="control" %}
+          {% for item in form.render_items %}
+            {% if item.is_question %}
+              <div class="teamshifts-question-row" data-question-role="{{ item.role_id }}">
+                {% bootstrap_field item.field layout="control" %}
               </div>
             {% else %}
-              {% bootstrap_field field layout="control" %}
+              {% bootstrap_field item.field layout="control" %}
             {% endif %}
           {% endfor %}
           <div class="form-group">

--- a/teamshifts/templates/teamshifts/cfv_settings.html
+++ b/teamshifts/templates/teamshifts/cfv_settings.html
@@ -4,6 +4,7 @@
 {% load static %}
 {% block custom_header %}
     {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% static 'orga/css/question-toggles.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'pretixcontrol/css/order-form-toggles.css' %}">
     <script defer src="{% static 'orga/js/questionToggles.js' %}"></script>
     <script defer src="{% static 'teamshifts/cfv_settings.js' %}"></script>
@@ -31,7 +32,7 @@
         <fieldset>
             <legend>{% trans "Application fields" %}</legend>
             <div class="table-responsive-sm">
-                <table class="table table-sm order-form-option-table">
+                <table class="table table-sm cfp-option-table">
                     <thead>
                         <tr>
                             <th>{% trans "Field" %}</th>

--- a/teamshifts/templates/teamshifts/cfv_settings.html
+++ b/teamshifts/templates/teamshifts/cfv_settings.html
@@ -2,16 +2,13 @@
 {% load i18n %}
 {% load bootstrap3 %}
 {% load static %}
-
 {% block custom_header %}
     {{ block.super }}
-    <link rel="stylesheet" type="text/css" href="{% static 'orga/css/question-toggles.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'pretixcontrol/css/order-form-toggles.css' %}">
     <script defer src="{% static 'orga/js/questionToggles.js' %}"></script>
     <script defer src="{% static 'teamshifts/cfv_settings.js' %}"></script>
 {% endblock %}
-
 {% block title %}{{ cfm.title }} :: {{ request.event.name }}{% endblock %}
-
 {% block content %}
     <nav id="event-nav" class="header-nav">
         <div class="navigation">
@@ -20,11 +17,9 @@
             </div>
         </div>
     </nav>
-
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
         {% bootstrap_form_errors form %}
-
         <fieldset>
             <legend>{% trans "Settings" %}</legend>
             {% bootstrap_field form.title layout="control" %}
@@ -33,98 +28,130 @@
             {% bootstrap_field form.deadline layout="control" %}
             {% bootstrap_field form.description layout="control" %}
         </fieldset>
-
         <fieldset>
-            <legend>{% trans "Application questions" %}</legend>
-            <p class="help-block">
-                {% blocktrans trimmed %}
-                    Custom questions you add here are shown to applicants on the public
-                    application form. Each question can apply to every role or only to a
-                    specific role.
-                {% endblocktrans %}
-            </p>
-            {% if questions %}
-                <div class="table-responsive">
-                    <table class="table table-hover table-quotas">
-                        <thead>
-                            <tr>
-                                <th>{% trans "Question" %}</th>
-                                <th>{% trans "Field type" %}</th>
-                                <th>{% trans "Role" %}</th>
-                                <th class="text-center">{% trans "Required" %}</th>
-                                <th class="text-center">{% trans "Active" %}</th>
-                                <th class="action-col-2"></th>
-                            </tr>
-                        </thead>
-                        <tbody data-dnd-url="{% url 'plugins:teamshifts:question_reorder' organizer=request.organizer.slug event=request.event.slug %}">
-                            {% for q in questions %}
-                                <tr data-dnd-id="{{ q.pk }}">
-                                    <td>
-                                        <a href="{% url 'plugins:teamshifts:question_edit' organizer=request.organizer.slug event=request.event.slug pk=q.pk %}">
-                                            <strong>{{ q.question }}</strong>
-                                        </a>
-                                    </td>
-                                    <td>{{ q.get_variant_display }}</td>
-                                    <td>
-                                        {% if q.role %}
-                                            <span class="label label-info">{{ q.role.name }}</span>
-                                        {% else %}
-                                            <span class="text-muted">{% trans "All roles" %}</span>
-                                        {% endif %}
-                                    </td>
-                                    <td class="text-center">
-                                        <div class="required-status-wrapper" data-current="{% if q.required %}required{% else %}optional{% endif %}">
-                                            <select class="required-status-dropdown"
-                                                    data-question-id="{{ q.pk }}"
-                                                    data-current="{% if q.required %}required{% else %}optional{% endif %}"
-                                                    aria-label="{% blocktrans with name=q.question %}Required status for {{ name }}{% endblocktrans %}">
-                                                <option value="optional" {% if not q.required %}selected{% endif %} data-color="optional">{% trans "Optional" %}</option>
-                                                <option value="required" {% if q.required %}selected{% endif %} data-color="required">{% trans "Required" %}</option>
-                                            </select>
-                                        </div>
-                                    </td>
-                                    <td class="text-center">
-                                        <label class="toggle-switch"
-                                               data-question-id="{{ q.pk }}"
-                                               data-field="active"
-                                               aria-label="{% blocktrans with name=q.question %}Toggle active state for {{ name }}{% endblocktrans %}">
-                                            <input type="checkbox" {% if q.active %}checked{% endif %}>
-                                            <span class="toggle-slider"></span>
-                                        </label>
-                                    </td>
-                                    <td class="text-right flip dnd-container">
-                                        <a class="btn btn-default btn-sm"
-                                           href="{% url 'plugins:teamshifts:question_edit' organizer=request.organizer.slug event=request.event.slug pk=q.pk %}"
-                                           title="{% trans 'Edit' %}">
-                                            <i class="fa fa-edit"></i>
-                                        </a>
-                                        <button type="submit"
-                                                formaction="{% url 'plugins:teamshifts:question_delete' organizer=request.organizer.slug event=request.event.slug pk=q.pk %}"
-                                                class="btn btn-delete btn-danger btn-sm"
-                                                data-no-loading
-                                                title="{% trans 'Delete' %}"
-                                                data-confirm="{% blocktrans trimmed with name=q.question %}Delete question &quot;{{ name }}&quot;?{% endblocktrans %}">
-                                            <i class="fa fa-trash"></i>
-                                        </button>
-                                    </td>
+            <legend>{% trans "Application fields" %}</legend>
+            <div class="table-responsive-sm">
+                <table class="table table-sm order-form-option-table">
+                    <thead>
+                        <tr>
+                            <th>{% trans "Field" %}</th>
+                            <th class="text-center">{% trans "Active" %}</th>
+                            <th class="text-center">{% trans "Required" %}</th>
+                            <th>{% trans "Role" %}</th>
+                            <th class="action-col-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody data-dnd-url="{% url 'plugins:teamshifts:question_reorder' organizer=request.organizer.slug event=request.event.slug %}">
+                        {% for row in unified_rows %}
+                            {% if row.kind == 'builtin' %}
+                                <tr data-dnd-id="{{ row.key }}">
+                                    <th>{{ row.label }}</th>
+                                    {% if row.locked %}
+                                        <td class="text-center">
+                                            <label class="toggle-switch always-on"
+                                                   aria-label="{% blocktrans with name=row.label %}{{ name }} is always active{% endblocktrans %}">
+                                                <input type="checkbox" checked disabled>
+                                                <span class="toggle-slider"></span>
+                                            </label>
+                                        </td>
+                                        <td class="text-center">
+                                            <div class="required-status-wrapper" data-current="required">
+                                                <select class="required-status-dropdown" disabled aria-readonly="true" data-current="required"
+                                                        aria-label="{% blocktrans with name=row.label %}{{ name }} is always required{% endblocktrans %}">
+                                                    <option value="required" selected>{% trans "Required" %}</option>
+                                                </select>
+                                            </div>
+                                        </td>
+                                    {% else %}
+                                        <td class="text-center">
+                                            <label class="toggle-switch" data-field-id="id_ask_{{ row.key }}"
+                                                   aria-label="{% blocktrans with name=row.label %}Toggle active state for {{ name }}{% endblocktrans %}">
+                                                <input type="checkbox" {% if row.ask_state != 'do_not_ask' %}checked{% endif %}>
+                                                <span class="toggle-slider"></span>
+                                            </label>
+                                            <input type="hidden" name="ask_{{ row.key }}" value="{{ row.ask_state }}"
+                                                   id="id_ask_{{ row.key }}" data-is-question-field="true">
+                                        </td>
+                                        <td class="text-center">
+                                            <div class="required-status-wrapper" data-current="{% if row.ask_state == 'required' %}required{% else %}optional{% endif %}">
+                                                <select class="required-status-dropdown" data-field-id="id_ask_{{ row.key }}"
+                                                        data-current="{% if row.ask_state == 'required' %}required{% else %}optional{% endif %}"
+                                                        aria-label="{% blocktrans with name=row.label %}Required status for {{ name }}{% endblocktrans %}">
+                                                    <option value="optional" {% if row.ask_state == 'optional' or row.ask_state == 'do_not_ask' %}selected{% endif %}>{% trans "Optional" %}</option>
+                                                    <option value="required" {% if row.ask_state == 'required' %}selected{% endif %}>{% trans "Required" %}</option>
+                                                </select>
+                                            </div>
+                                        </td>
+                                    {% endif %}
+                                    <td><span class="text-muted">{% trans "All roles" %}</span></td>
+                                    <td class="text-right flip dnd-container"></td>
                                 </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            {% else %}
-                <p class="text-muted">{% trans "No custom questions yet." %}</p>
-            {% endif %}
+                            {% else %}
+                                {% with q=row.question %}
+                                    <tr data-dnd-id="{{ q.pk }}">
+                                        <td>
+                                            <a href="{% url 'plugins:teamshifts:question_edit' organizer=request.organizer.slug event=request.event.slug pk=q.pk %}">
+                                                <strong>{{ q.question }}</strong>
+                                            </a>
+                                            <span class="badge badge-info text-dark">{% trans "Custom" %}</span>
+                                        </td>
+                                        <td class="text-center">
+                                            <label class="toggle-switch" data-question-id="{{ q.pk }}" data-field="active"
+                                                   aria-label="{% blocktrans with name=q.question %}Toggle active state for {{ name }}{% endblocktrans %}">
+                                                <input type="checkbox" {% if q.active %}checked{% endif %}>
+                                                <span class="toggle-slider"></span>
+                                            </label>
+                                        </td>
+                                        <td class="text-center">
+                                            <div class="required-status-wrapper" data-current="{% if q.required %}required{% else %}optional{% endif %}">
+                                                <select class="required-status-dropdown" data-question-id="{{ q.pk }}"
+                                                        data-current="{% if q.required %}required{% else %}optional{% endif %}"
+                                                        aria-label="{% blocktrans with name=q.question %}Required status for {{ name }}{% endblocktrans %}">
+                                                    <option value="optional" {% if not q.required %}selected{% endif %}>{% trans "Optional" %}</option>
+                                                    <option value="required" {% if q.required %}selected{% endif %}>{% trans "Required" %}</option>
+                                                </select>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            {% if q.role %}
+                                                <span class="label label-info">{{ q.role.name }}</span>
+                                            {% else %}
+                                                <span class="text-muted">{% trans "All roles" %}</span>
+                                            {% endif %}
+                                        </td>
+                                        <td class="text-right flip dnd-container">
+                                            <a class="btn btn-sm btn-info"
+                                               href="{% url 'plugins:teamshifts:question_edit' organizer=request.organizer.slug event=request.event.slug pk=q.pk %}"
+                                               title="{% trans 'Edit' %}">
+                                                <i class="fa fa-edit"></i>
+                                            </a>
+                                            <button type="submit"
+                                                    formaction="{% url 'plugins:teamshifts:question_delete' organizer=request.organizer.slug event=request.event.slug pk=q.pk %}"
+                                                    class="btn btn-sm btn-danger"
+                                                    data-no-loading
+                                                    title="{% trans 'Delete' %}"
+                                                    data-confirm="{% blocktrans trimmed with name=q.question %}Delete question &quot;{{ name }}&quot;?{% endblocktrans %}">
+                                                <i class="fa fa-trash"></i>
+                                            </button>
+                                        </td>
+                                    </tr>
+                                {% endwith %}
+                            {% endif %}
+                        {% empty %}
+                            <tr>
+                                <td colspan="5" class="text-muted text-center">{% trans "No fields configured yet." %}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
             <a href="{% url 'plugins:teamshifts:question_create' organizer=request.organizer.slug event=request.event.slug %}"
                class="btn btn-default">
-                <span class="fa fa-plus"></span> {% trans "Add a question" %}
+                <span class="fa fa-plus"></span> {% trans "Add a custom question" %}
             </a>
         </fieldset>
-
         <div class="form-group submit-group">
-            <button type="submit" class="btn btn-primary btn-save">
-                {% trans "Save" %}
-            </button>
+            <button type="submit" class="btn btn-primary btn-save">{% trans "Save" %}</button>
             <a href="{% url 'plugins:teamshifts:dashboard' organizer=request.organizer.slug event=request.event.slug %}"
                class="btn btn-default btn-lg">
                 {% trans "Cancel" %}

--- a/teamshifts/templates/teamshifts/question_edit.html
+++ b/teamshifts/templates/teamshifts/question_edit.html
@@ -27,7 +27,6 @@
             {% bootstrap_field form.role layout='control' %}
             {% bootstrap_field form.required layout='control' %}
             {% bootstrap_field form.options layout='control' %}
-            {% bootstrap_field form.position layout='control' %}
             {% bootstrap_field form.active layout='control' %}
         </fieldset>
         <div class='form-group submit-group'>

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -66,7 +66,7 @@ class CFMSettingsView(EventPermissionRequiredMixin, View):
 
     def _questions(self):
         with scope(event=self.request.event):
-            return list(TeamApplicationQuestion.objects.filter(event=self.request.event).select_related("role").order_by("position", "pk"))
+            return list(TeamApplicationQuestion.objects.filter(event=self.request.event).select_related("role").order_by("pk"))
 
     def _unified_rows(self, cfm, questions):
         question_map = {q.pk: q for q in questions}
@@ -264,9 +264,6 @@ class QuestionReorderView(EventPermissionRequiredMixin, View):
 
         event = request.event
         with scope(event=event):
-            for position, item in enumerate(normalised):
-                if isinstance(item, int):
-                    TeamApplicationQuestion.objects.filter(pk=item, event=event).update(position=position)
             try:
                 cfm = event.call_for_team_members
                 cfm.field_order = normalised

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -19,6 +19,8 @@ from .forms import (
     render_answer_for_review,
 )
 from .models import (
+    CFM_BUILTIN_FIELD_KEYS,
+    CFM_LOCKED_FIELDS,
     ApplicationStatus,
     CallForTeamMembers,
     Shift,
@@ -26,6 +28,7 @@ from .models import (
     TeamApplicationQuestion,
     TeamMemberApplication,
     TeamRole,
+    normalize_field_order,
 )
 
 
@@ -53,11 +56,6 @@ class TeamShiftsDashboard(EventPermissionRequiredMixin, TemplateView):
 
 
 class CFMSettingsView(EventPermissionRequiredMixin, View):
-    """
-    Settings page / form builder: shows CFM settings plus the inline list
-    of organiser-defined custom application questions.
-    """
-
     permission = "can_change_event_settings"
     template_name = "teamshifts/cfv_settings.html"
 
@@ -70,20 +68,76 @@ class CFMSettingsView(EventPermissionRequiredMixin, View):
         with scope(event=self.request.event):
             return list(TeamApplicationQuestion.objects.filter(event=self.request.event).select_related("role").order_by("position", "pk"))
 
+    def _unified_rows(self, cfm, questions):
+        question_map = {q.pk: q for q in questions}
+        order = normalize_field_order(list(cfm.field_order))
+
+        present_pks = {int(item) for item in order if not isinstance(item, str)}
+        for q in questions:
+            if q.pk not in present_pks:
+                order.append(q.pk)
+
+        label_map = {
+            "full_name": _("Full name"),
+            "email": _("Email address"),
+            "phone": _("Phone / Mobile"),
+            "role": _("Role"),
+            "availability": _("Availability notes"),
+        }
+
+        rows = []
+        for item in order:
+            if isinstance(item, str):
+                rows.append(
+                    {
+                        "kind": "builtin",
+                        "key": item,
+                        "label": label_map.get(item, item),
+                        "ask_state": cfm.get_ask_state(item),
+                        "locked": item in CFM_LOCKED_FIELDS,
+                        "question": None,
+                    }
+                )
+            else:
+                q = question_map.get(int(item))
+                if q is None:
+                    continue
+                rows.append(
+                    {
+                        "kind": "custom",
+                        "key": q.pk,
+                        "label": str(q.question),
+                        "ask_state": None,
+                        "locked": False,
+                        "question": q,
+                    }
+                )
+        return rows
+
+    def _ctx(self, cfm, form, questions):
+        return {
+            "form": form,
+            "cfm": cfm,
+            "questions": questions,
+            "unified_rows": self._unified_rows(cfm, questions),
+        }
+
     def get(self, request, *args, **kwargs):
         cfm = self._get_cfm()
+        questions = self._questions()
         form = CallForTeamMembersForm(instance=cfm, locales=request.event.settings.locales)
-        return render(request, self.template_name, {"form": form, "cfm": cfm, "questions": self._questions()})
+        return render(request, self.template_name, self._ctx(cfm, form, questions))
 
     def post(self, request, *args, **kwargs):
         cfm = self._get_cfm()
+        questions = self._questions()
         form = CallForTeamMembersForm(request.POST, instance=cfm, locales=request.event.settings.locales)
         if form.is_valid():
             with scope(event=request.event):
                 form.save()
             messages.success(request, _("Settings saved."))
             return redirect("plugins:teamshifts:cfm_settings", organizer=request.organizer.slug, event=request.event.slug)
-        return render(request, self.template_name, {"form": form, "cfm": cfm, "questions": self._questions()})
+        return render(request, self.template_name, self._ctx(cfm, form, questions))
 
 
 class TeamRoleListView(EventPermissionRequiredMixin, View):
@@ -128,8 +182,6 @@ class TeamRoleDeleteView(EventPermissionRequiredMixin, View):
 
 
 class QuestionEditView(EventPermissionRequiredMixin, View):
-    """Create (no pk) or edit (pk) a custom application question."""
-
     permission = "can_change_event_settings"
     template_name = "teamshifts/question_edit.html"
 
@@ -151,6 +203,16 @@ class QuestionEditView(EventPermissionRequiredMixin, View):
             with scope(event=request.event):
                 saved = form.save()
             if instance is None:
+                with scope(event=request.event):
+                    try:
+                        cfm = request.event.call_for_team_members
+                        order = normalize_field_order(list(cfm.field_order))
+                        if saved.pk not in order:
+                            order.append(saved.pk)
+                        cfm.field_order = order
+                        cfm.save(update_fields=["field_order"])
+                    except CallForTeamMembers.DoesNotExist:
+                        pass
                 messages.success(request, _("Question '%s' added.") % saved.question)
             else:
                 messages.success(request, _("Question saved."))
@@ -166,7 +228,14 @@ class QuestionDeleteView(EventPermissionRequiredMixin, View):
         with scope(event=event):
             question = get_object_or_404(TeamApplicationQuestion, pk=kwargs["pk"], event=event)
             label = str(question.question)
+            pk = question.pk
             question.delete()
+            try:
+                cfm = event.call_for_team_members
+                cfm.field_order = [item for item in cfm.field_order if item != pk]
+                cfm.save(update_fields=["field_order"])
+            except CallForTeamMembers.DoesNotExist:
+                pass
         messages.success(request, _("Question '%s' deleted.") % label)
         return redirect("plugins:teamshifts:cfm_settings", organizer=request.organizer.slug, event=event.slug)
 
@@ -177,14 +246,31 @@ class QuestionReorderView(EventPermissionRequiredMixin, View):
     def post(self, request, *args, **kwargs):
         try:
             data = json.loads(request.body.decode("utf-8"))
-            pks = [str(pk) for pk in data.get("ids", [])]
+            raw_ids = data.get("ids", [])
         except (json.JSONDecodeError, ValueError, AttributeError):
             return HttpResponse(status=400)
+
+        normalised = []
+        for item in raw_ids:
+            if isinstance(item, str) and item in CFM_BUILTIN_FIELD_KEYS:
+                normalised.append(item)
+            elif isinstance(item, int) or (isinstance(item, str) and item.isdigit()):
+                normalised.append(int(item))
+            else:
+                return HttpResponse(status=400)
+
         event = request.event
         with scope(event=event):
-            for position, pk in enumerate(pks):
-                if pk.isdigit():
-                    TeamApplicationQuestion.objects.filter(pk=int(pk), event=event).update(position=position)
+            for position, item in enumerate(normalised):
+                if isinstance(item, int):
+                    TeamApplicationQuestion.objects.filter(pk=item, event=event).update(position=position)
+            try:
+                cfm = event.call_for_team_members
+                cfm.field_order = normalised
+                cfm.save(update_fields=["field_order"])
+            except CallForTeamMembers.DoesNotExist:
+                pass
+
         return HttpResponse(status=204)
 
 
@@ -298,6 +384,7 @@ class PublicApplyView(FormView):
         kwargs = self.get_form_kwargs()
         kwargs["event"] = self.event
         kwargs["user"] = self.request.user
+        kwargs["cfm"] = self.cfm
         with scope(event=self.event):
             kwargs["applied_role_ids"] = list(TeamMemberApplication.objects.filter(event=self.event, user=self.request.user).values_list("role_id", flat=True))
         return TeamMemberApplicationForm(**kwargs)
@@ -318,7 +405,7 @@ class PublicApplyView(FormView):
             messages.error(self.request, _("Applications are not currently open for this event."))
             return self.form_invalid(form)
         role = form.cleaned_data["role"]
-        name = form.cleaned_data.get("name", "").strip()
+        full_name = form.cleaned_data.get("full_name", "").strip()
         with scope(event=event):
             if TeamMemberApplication.objects.filter(event=event, user=self.request.user, role=role).exists():
                 messages.error(self.request, _("You have already applied for the role '%s'.") % role.name)
@@ -338,8 +425,8 @@ class PublicApplyView(FormView):
                 if question.role_id and question.role_id != role.pk:
                     continue
                 TeamApplicationAnswer.objects.create(application=application, question=question, answer=answer_text)
-        if name and name != self.request.user.fullname:
-            self.request.user.fullname = name
+        if full_name and full_name != self.request.user.fullname:
+            self.request.user.fullname = full_name
             self.request.user.save(update_fields=["fullname"])
         messages.success(self.request, _("Your application for '%s' has been submitted.") % role.name)
         return redirect(

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -259,6 +259,9 @@ class QuestionReorderView(EventPermissionRequiredMixin, View):
             else:
                 return HttpResponse(status=400)
 
+        if len(set(str(i) for i in normalised)) != len(normalised):
+            return HttpResponse(status=400)
+
         event = request.event
         with scope(event=event):
             for position, item in enumerate(normalised):


### PR DESCRIPTION
### Summary

Unifies the five built-in application fields (Full name, Email, Phone, Role, Availability) with custom questions into a single drag-and-drop table on the CFM Settings page. Each built-in field gets per-field Active toggle and Required dropdown — matching the pattern used in ticket order forms and CFP speaker information. The `position` field on `TeamApplicationQuestion` is fully removed; `field_order` JSONField on `CallForTeamMembers` is now the single source of truth for ordering.

### Changes

- **Model** — Add `ask_full_name`, `ask_phone`, `ask_availability` (three-state: `do_not_ask`/`optional`/`required`), `ask_email`, `ask_role` (locked to `required`), and `field_order` JSONField to `CallForTeamMembers`. Remove `position` field from `TeamApplicationQuestion`.
- **Migrations** — `0004_cfm_configurable_default_fields` adds 6 columns and backfills `field_order` from existing question positions. `0005_remove_teamapplicationquestion_position` drops the now-redundant `position` column.
- **Form** — `CallForTeamMembersForm` exposes the editable `ask_*` fields; `TeamMemberApplicationForm` renders fields in `field_order` order, omitting `do_not_ask` fields. Removed `position` from `TeamApplicationQuestionForm`.
- **Views** — `CFMSettingsView` builds unified rows; `QuestionReorderView` accepts mixed string keys + integer PKs and persists to `cfm.field_order` only (no more position writes); `QuestionEditView`/`QuestionDeleteView` sync `field_order`.
- **Template** — `cfv_settings.html` uses `cfp-option-table` with `data-field-id` bound toggles/dropdowns (form POST via `questionToggles.js`) for built-in rows, preserving existing AJAX pattern for custom rows. Removed `form.position` from question edit. Fixed `apply.html` template error with dashed-attr lookup.
- **JS** — `cfv_settings.js` handles `show_on_menu` grey-out only; relies on `orga/js/questionToggles.js` for toggle/dropdown sync.
- **Admin** — Removed `position` from `TeamApplicationQuestionAdmin` list_display and ordering.


https://github.com/user-attachments/assets/317af64d-8337-4bf8-8100-151cf2cd34b6


### Risks / Follow-up

- Existing CFM rows get `field_order` backfilled in migration 0004; no data loss
- `ask_email` and `ask_role` are locked at the DB level (default `required`) — organiser cannot disable them
- The `position` column is dropped in migration 0005; irreversible but safe since `field_order` replaces it entirely

#### Related

- Closes #21