### PR TITLE
fix: public url plugin live checks

### DIFF
--- a/teamshifts/urls.py
+++ b/teamshifts/urls.py
@@ -3,18 +3,20 @@ from eventyay.common.urls import OrganizerSlugConverter  # noqa: F401
 
 from . import views
 
-urlpatterns = [
+event_patterns = [
     path(
-        "<orgslug:organizer>/<slug:event>/teamshifts/apply/",
+        "teamshifts/apply/",
         views.PublicApplyView.as_view(),
         name="apply",
     ),
     path(
-        "<orgslug:organizer>/<slug:event>/teamshifts/apply/thanks/",
+        "teamshifts/apply/thanks/",
         views.PublicApplyThanksView.as_view(),
         name="apply_thanks",
     ),
-    # Organiser back-office URLs (require can_change_event_settings)
+]
+
+urlpatterns = [
     path(
         "teamshifts/event/<orgslug:organizer>/<slug:event>/",
         views.TeamShiftsDashboard.as_view(),

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -32,7 +32,14 @@ from .models import (
 )
 
 
-class TeamShiftsDashboard(EventPermissionRequiredMixin, TemplateView):
+class PluginActiveMixin:
+    def dispatch(self, request, *args, **kwargs):
+        if "teamshifts" not in request.event.get_plugins():
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+
+class TeamShiftsDashboard(PluginActiveMixin, EventPermissionRequiredMixin, TemplateView):
     permission = "can_change_event_settings"
     template_name = "teamshifts/dashboard.html"
 
@@ -55,7 +62,7 @@ class TeamShiftsDashboard(EventPermissionRequiredMixin, TemplateView):
         return ctx
 
 
-class CFMSettingsView(EventPermissionRequiredMixin, View):
+class CFMSettingsView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     permission = "can_change_event_settings"
     template_name = "teamshifts/cfv_settings.html"
 
@@ -140,7 +147,7 @@ class CFMSettingsView(EventPermissionRequiredMixin, View):
         return render(request, self.template_name, self._ctx(cfm, form, questions))
 
 
-class TeamRoleListView(EventPermissionRequiredMixin, View):
+class TeamRoleListView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     permission = "can_change_event_settings"
     template_name = "teamshifts/roles.html"
 
@@ -163,7 +170,7 @@ class TeamRoleListView(EventPermissionRequiredMixin, View):
         return render(request, self.template_name, {"roles": roles, "form": form})
 
 
-class TeamRoleDeleteView(EventPermissionRequiredMixin, View):
+class TeamRoleDeleteView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     permission = "can_change_event_settings"
 
     def post(self, request, *args, **kwargs):
@@ -181,7 +188,7 @@ class TeamRoleDeleteView(EventPermissionRequiredMixin, View):
         return redirect("plugins:teamshifts:roles", organizer=request.organizer.slug, event=event.slug)
 
 
-class QuestionEditView(EventPermissionRequiredMixin, View):
+class QuestionEditView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     permission = "can_change_event_settings"
     template_name = "teamshifts/question_edit.html"
 
@@ -220,7 +227,7 @@ class QuestionEditView(EventPermissionRequiredMixin, View):
         return render(request, self.template_name, {"form": form, "question": instance})
 
 
-class QuestionDeleteView(EventPermissionRequiredMixin, View):
+class QuestionDeleteView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     permission = "can_change_event_settings"
 
     def post(self, request, *args, **kwargs):
@@ -240,7 +247,7 @@ class QuestionDeleteView(EventPermissionRequiredMixin, View):
         return redirect("plugins:teamshifts:cfm_settings", organizer=request.organizer.slug, event=event.slug)
 
 
-class QuestionReorderView(EventPermissionRequiredMixin, View):
+class QuestionReorderView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     permission = "can_change_event_settings"
 
     def post(self, request, *args, **kwargs):
@@ -274,7 +281,7 @@ class QuestionReorderView(EventPermissionRequiredMixin, View):
         return HttpResponse(status=204)
 
 
-class QuestionToggleView(EventPermissionRequiredMixin, View):
+class QuestionToggleView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     permission = "can_change_event_settings"
 
     def post(self, request, *args, **kwargs):
@@ -304,7 +311,7 @@ class QuestionToggleView(EventPermissionRequiredMixin, View):
         return JsonResponse({"success": True, "field": field, "value": value})
 
 
-class ApplicationListView(EventPermissionRequiredMixin, TemplateView):
+class ApplicationListView(PluginActiveMixin, EventPermissionRequiredMixin, TemplateView):
     permission = "can_change_event_settings"
     template_name = "teamshifts/applications.html"
 
@@ -339,7 +346,7 @@ class ApplicationListView(EventPermissionRequiredMixin, TemplateView):
         return ctx
 
 
-class ApplicationStatusView(EventPermissionRequiredMixin, View):
+class ApplicationStatusView(PluginActiveMixin, EventPermissionRequiredMixin, View):
     permission = "can_change_event_settings"
 
     def post(self, request, *args, **kwargs):

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -375,6 +375,8 @@ class PublicApplyView(FormView):
     template_name = "teamshifts/apply.html"
 
     def dispatch(self, request, *args, **kwargs):
+        if "teamshifts" not in request.event.get_plugins():
+            raise Http404
         if not request.event.live:
             raise Http404
         if not request.user.is_authenticated:
@@ -450,6 +452,8 @@ class PublicApplyThanksView(TemplateView):
     template_name = "teamshifts/apply_thanks.html"
 
     def dispatch(self, request, *args, **kwargs):
+        if "teamshifts" not in request.event.get_plugins():
+            raise Http404
         if not request.event.live:
             raise Http404
         if not request.user.is_authenticated:

--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -368,6 +368,8 @@ class PublicApplyView(FormView):
     template_name = "teamshifts/apply.html"
 
     def dispatch(self, request, *args, **kwargs):
+        if not request.event.live:
+            raise Http404
         if not request.user.is_authenticated:
             login_url = reverse("eventyay_common:auth.login")
             return redirect(f"{login_url}?next={request.get_full_path()}")
@@ -441,6 +443,8 @@ class PublicApplyThanksView(TemplateView):
     template_name = "teamshifts/apply_thanks.html"
 
     def dispatch(self, request, *args, **kwargs):
+        if not request.event.live:
+            raise Http404
         if not request.user.is_authenticated:
             login_url = reverse("eventyay_common:auth.login")
             return redirect(f"{login_url}?next={request.get_full_path()}")


### PR DESCRIPTION
### Summary

Fixes a bug where TeamShifts public URLs (`/organizer/event/teamshifts/apply/`) remained accessible even when the plugin was disabled for the event or the event was not live. Also guards all organiser back-office URLs with the same plugin-active check.

### What changed

**urls.py**
- Split into `event_patterns` (public apply paths) and `urlpatterns` (organiser back-office paths)
- Public paths no longer carry the `<orgslug:organizer>/<slug:event>/` prefix — the mount provides it via `plugin_event_urls`

**views.py**
- Added `PluginActiveMixin` — checks `"teamshifts" not in request.event.get_plugins()` and raises 404. Applied to all 10 back-office view classes.
- Added explicit `"teamshifts" not in request.event.get_plugins()` + `not request.event.live` checks in `PublicApplyView.dispatch` and `PublicApplyThanksView.dispatch`

### Why the explicit check is needed

`plugin_event_urls` wraps views with `_event_view(require_plugin=plugin)`, but `_detect_event` skips that check for apps in `CORE_MODULES`. Since `teamshifts` is in `INSTALLED_APPS` (and therefore `CORE_MODULES`), the framework-level guard was silently bypassed. The socialmedia plugin handles this the same way — explicit `get_plugins()` check in every view.


https://github.com/user-attachments/assets/7e04f50a-8e0e-42f2-8e69-f61a4bfd9814


https://github.com/user-attachments/assets/6726754b-57dd-43d3-81ee-737761e5acb6



### Risk

Low. No URL shape changes for end users. Only the internal dispatch mechanism and view guards change. Existing `reverse()` calls and nav signal entries continue to work unchanged.

#### Related

Closes: #22 