### PR TITLE
fix: remove event.live guard from public apply views to prevent 404

### DIFF
--- a/teamshifts/views.py
+++ b/teamshifts/views.py
@@ -377,8 +377,6 @@ class PublicApplyView(FormView):
     def dispatch(self, request, *args, **kwargs):
         if "teamshifts" not in request.event.get_plugins():
             raise Http404
-        if not request.event.live:
-            raise Http404
         if not request.user.is_authenticated:
             login_url = reverse("eventyay_common:auth.login")
             return redirect(f"{login_url}?next={request.get_full_path()}")
@@ -453,8 +451,6 @@ class PublicApplyThanksView(TemplateView):
 
     def dispatch(self, request, *args, **kwargs):
         if "teamshifts" not in request.event.get_plugins():
-            raise Http404
-        if not request.event.live:
             raise Http404
         if not request.user.is_authenticated:
             login_url = reverse("eventyay_common:auth.login")


### PR DESCRIPTION
### Summary
Remove `event.live` guard from `PublicApplyView` and `PublicApplyThanksView`.


https://github.com/user-attachments/assets/08ad4c7d-a57a-4e30-8628-8bedfe184667



### Risk
Low. Only removes an overly strict guard. No new logic added.

Closes #33

## Summary by Sourcery

Bug Fixes:
- Allow authenticated users to access public apply and thank-you views for team shifts even when the event is not flagged as live, preventing erroneous 404 responses.