### PR TITLE
fix: enforce application deadline by parsing with timezone awareness

### DIFF
--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.utils.translation import gettext_lazy as _
 from django_countries import countries
 from django_scopes import scopes_disabled
+from eventyay.control.forms import SplitDateTimeField, SplitDateTimePickerWidget
 
 from .models import (
     CFM_BUILTIN_FIELD_KEYS,
@@ -12,8 +13,6 @@ from .models import (
     TeamRole,
     normalize_field_order,
 )
-
-from eventyay.control.forms import SplitDateTimeField, SplitDateTimePickerWidget
 
 
 class CallForTeamMembersSettingsForm(forms.ModelForm):

--- a/teamshifts/forms.py
+++ b/teamshifts/forms.py
@@ -13,6 +13,8 @@ from .models import (
     normalize_field_order,
 )
 
+from eventyay.control.forms import SplitDateTimeField, SplitDateTimePickerWidget
+
 
 class CallForTeamMembersSettingsForm(forms.ModelForm):
     class Meta:
@@ -24,11 +26,11 @@ class CallForTeamMembersSettingsForm(forms.ModelForm):
             "deadline",
             "description",
         )
+        field_classes = {
+            "deadline": SplitDateTimeField,
+        }
         widgets = {
-            "deadline": forms.DateTimeInput(
-                attrs={"class": "form-control datetimepicker"},
-                format="%Y-%m-%d %H:%M:%S",
-            ),
+            "deadline": SplitDateTimePickerWidget(),
             "title": forms.TextInput(attrs={"class": "form-control"}),
         }
 


### PR DESCRIPTION
### Summary
Fixes an issue where the Call for Volunteers application form remained accessible and accepted submissions even after the application deadline had passed.

### What changed
- **`teamshifts/forms.py`**: Replaced the naive `forms.DateTimeInput` with `SplitDateTimeField` and `SplitDateTimePickerWidget` (from `eventyay.control.forms`) in the `CallForTeamMembersSettingsForm`. 

### Why this is needed
The native `DateTimeInput` was parsing the deadline without properly taking the event's local timezone into account. When the `is_open` property later compared this deadline against `timezone.now()` (UTC), it incorrectly evaluated to `True`, leaving the form open past the intended local time. Using `SplitDateTimeField` ensures the input is correctly localized and stored, allowing the deadline to be accurately enforced.


https://github.com/user-attachments/assets/369fe4ac-6005-4885-9eb1-91f0fc46eefc



Closes #58 
